### PR TITLE
Fixing links

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,25 +5,24 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
 
-    <title>Are we IPFS yt et?</title>
+    <title>Are we IPFS yet?</title>
     <meta name="description" content="...kinda, yeah! The foundations are there, but there's still a lot of fine-tuning and advanced features to implement.">
-    <meta name="image" content="./img/open-graph-preview.png">
+    <meta name="image" content="https://raw.githubusercontent.com/rs-ipfs/areweipfsyet.rs/master/img/open-graph-preview.png">
 
     <!-- Schema.org for Google -->
     <meta itemprop="name" content="Are we IPFS yet?">
     <meta itemprop="description" content="...kinda, yeah! The foundations are there, but there's still a lot of fine-tuning and advanced features to implement.">
-    <meta itemprop="image" content="./img/open-graph-preview.png">
+    <meta itemprop="image" content="https://raw.githubusercontent.com/rs-ipfs/areweipfsyet.rs/master/img/open-graph-preview.png">
 
     <!-- Twitter -->
     <meta name="twitter:card" content="summary">
     <meta name="twitter:title" content="Are we IPFS yet?">
     <meta name="twitter:description" content="...kinda, yeah! The foundations are there, but there's still a lot of fine-tuning and advanced features to implement.">
-    <meta name="twitter:image:src" content="./img/twitter-preview.png">
-
+    <meta name="twitter:image:src" content="https://raw.githubusercontent.com/rs-ipfs/areweipfsyet.rs/master/img/twitter-preview.png">
     <!-- Open Graph general (Facebook, Pinterest & Google+) -->
     <meta name="og:title" content="Are we IPFS yet?">
     <meta name="og:description" content="...kinda, yeah! The foundations are there, but there's still a lot of fine-tuning and advanced features to implement.">
-    <meta name="og:image" content="./img/open-graph-preview.png">
+    <meta name="og:image" content="https://raw.githubusercontent.com/rs-ipfs/areweipfsyet.rs/master/img/open-graph-preview.png">
     <meta name="og:url" content="https://areweipfsyet.rs">
     <meta name="og:site_name" content="Are we IPFS yet?">
     <meta name="og:locale" content="en_US">
@@ -231,22 +230,22 @@
           tests provided by Protocol Labs
         </li>
         <li>
-          <a href="#">rust-ipfs-api</a> - A HTTP client for an existing
+          <a href="https://github.com/ferristseng/rust-ipfs-api">rust-ipfs-api</a> - A HTTP client for an existing
           go-ipfs or js-ipfs node. Supports both hyper and actix
         </li>
         <li>
-          <a href="#">ipfs-embed</a> - A light client implementation
+          <a href="https://github.com/ipfs-rust/ipfs-embed">ipfs-embed</a> - A light client implementation
           with a <a href="https://github.com/spacejam/sled">sled</a> backend
         </li>
         <li>
-          <a href="#">rust-ipld</a> - Basic rust ipld library supporting
+          <a href="https://github.com/ipfs-rust/rust-ipld">rust-ipld</a> - Basic rust ipld library supporting
           dag-cbor, dag-json and dag-pb formats
         </li>
         <li>
-          PolkaX's own <a href="#">rust-ipfs</a>
+          PolkaX's own <a href="https://github.com/PolkaX/rust-ipfs">rust-ipfs</a>
         </li>
         <li>
-          Parity's <a href="#">rust-libp2p</a>, which does a lot the of
+          Parity's <a href="https://github.com/libp2p/rust-libp2p">rust-libp2p</a>, which does a lot the of
           heavy lifting here
         </li>
       </ul>


### PR DESCRIPTION
This PR fixes the social media links by making them absolute (pointing to raw.github) and the ecosystem links which were erroneously left as "#"